### PR TITLE
Fixed fetching preferences for API key and secret

### DIFF
--- a/Cartridges/int_checkoutcom_sfra/cartridge/scripts/helpers/ckoHelper.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/scripts/helpers/ckoHelper.js
@@ -115,9 +115,9 @@ var ckoHelper = {
         var keys = {};
         var str = this.getValue('ckoMode').value == 'live' ? 'Live' : 'Sandbox';
 
-        keys.publicKey = this.getValue('cko' + str + 'PublicKey').value;
-        keys.secretKey = this.getValue('cko' +  str + 'SecretKey').value;
-        keys.privateSharedKey = this.getValue('cko' +  str + 'PrivateSharedKey').value;
+        keys.publicKey = this.getValue('cko' + str + 'PublicKey');
+        keys.secretKey = this.getValue('cko' +  str + 'SecretKey');
+        keys.privateSharedKey = this.getValue('cko' +  str + 'PrivateSharedKey');
 
         return keys;
     },


### PR DESCRIPTION
Hi David,
Can you please review and merge the changes we propose to the fetching of the API Key and secret since it now returns nulls, and the service is giving us a 401 Unauthorized for that reason.
Thank you,
Kiril (Tryzens)