### PR TITLE
Fixed Paypal always displaying issue: ECPINT-704

### DIFF
--- a/Cartridges/int_checkoutcom/cartridge/scripts/config/ckoApmFilterConfig.js
+++ b/Cartridges/int_checkoutcom/cartridge/scripts/config/ckoApmFilterConfig.js
@@ -70,7 +70,7 @@ var ckoApmFilterConfig = {
     	currencies	: ["USD", "CNY"]
     },
     paypal: {
-    	countries	: "",
+    	countries	: ["*"],
     	currencies	: ["AUD", "BRL", "CAD", "CZK", "DKK", "EUR", "HKD", "HUF", "INR", "ILS", "JPY", "MYR", "MXN", "TWD", "NZD", "NOK", "PHP", "PLN", "GBP", "RUB", "SGD", "SEK", "CHF", "THB", "USD"]
     }
 }

--- a/Cartridges/int_checkoutcom/cartridge/scripts/config/ckoApmFilterConfig.js
+++ b/Cartridges/int_checkoutcom/cartridge/scripts/config/ckoApmFilterConfig.js
@@ -68,6 +68,10 @@ var ckoApmFilterConfig = {
     alipay: {
     	countries	: "CN",
     	currencies	: ["USD", "CNY"]
+    },
+    paypal: {
+    	countries	: "",
+    	currencies	: ["AUD", "BRL", "CAD", "CZK", "DKK", "EUR", "HKD", "HUF", "INR", "ILS", "JPY", "MYR", "MXN", "TWD", "NZD", "NOK", "PHP", "PLN", "GBP", "RUB", "SGD", "SEK", "CHF", "THB", "USD"]
     }
 }
 

--- a/Cartridges/int_checkoutcom/cartridge/static/default/js/apm.js
+++ b/Cartridges/int_checkoutcom/cartridge/static/default/js/apm.js
@@ -79,10 +79,20 @@ function alternativePaymentsFilter() {
 
             // Loops through the apmfilterObject
             for (var apms in apmsFilterObject) {
+            	
+            	/*
+            	 * If the current apm country-code is empty and currency-code in
+            	 * the list of apms, match the current country-code and currency-code
+            	 */
+            	if (apmsFilterObject[apms].countries == '' && apmsFilterObject[apms].currencies.includes(filterObject.currency)) {
+
+                	// Show Apm in template
+                	$('#'+ apms).show();
+            	}
 
             	/*
             	 * If the current apm country-code and currency-code in
-            	 * the list of apms match the current country-code and currency-code
+            	 * the list of apms, match the current country-code and currency-code
             	 */
                 if (apmsFilterObject[apms].countries.includes(filterObject.country.toUpperCase()) && apmsFilterObject[apms].currencies.includes(filterObject.currency)) {
 

--- a/Cartridges/int_checkoutcom/cartridge/static/default/js/apm.js
+++ b/Cartridges/int_checkoutcom/cartridge/static/default/js/apm.js
@@ -79,22 +79,15 @@ function alternativePaymentsFilter() {
 
             // Loops through the apmfilterObject
             for (var apms in apmsFilterObject) {
+            	var condition1 = apmsFilterObject[apms].countries.includes(filterObject.country.toUpperCase());
+            	var condition2 = apmsFilterObject[apms].countries.includes('*');
+            	var condition3 = apmsFilterObject[apms].currencies.includes(filterObject.currency);
             	
-            	/*
-            	 * If the current apm country-code is empty and currency-code in
-            	 * the list of apms, match the current country-code and currency-code
-            	 */
-            	if (apmsFilterObject[apms].countries == '' && apmsFilterObject[apms].currencies.includes(filterObject.currency)) {
-
-                	// Show Apm in template
-                	$('#'+ apms).show();
-            	}
-
             	/*
             	 * If the current apm country-code and currency-code in
             	 * the list of apms, match the current country-code and currency-code
             	 */
-                if (apmsFilterObject[apms].countries.includes(filterObject.country.toUpperCase()) && apmsFilterObject[apms].currencies.includes(filterObject.currency)) {
+                if ((condition1 || condition2) && condition3) {
 
                 	// Show Apm in template
                 	$('#'+ apms).show();

--- a/Cartridges/int_checkoutcom/cartridge/templates/default/apm/apm.isml
+++ b/Cartridges/int_checkoutcom/cartridge/templates/default/apm/apm.isml
@@ -143,7 +143,7 @@
 	
 	<!-- This to include the Paypal apm form -->
 	<isif condition="${(dw.system.Site.getCurrent().getCustomPreferenceValue('ckoPaypalEnabled'))}">
-		<div id="paypal" class="apmBox">	
+		<div id="paypal" class="hideApm apmBox">	
 			<isinclude template="apm/payPal.isml"/>
 		</div>
 	</isif>


### PR DESCRIPTION
Paypal apms was always showing in every currency and local, even when paypal does not support those currencies. Using a paypal currency supported list, i have been able to fix this issue.
@david-fiaty-cko i have fixed the paypal amps always displaying issue and will like you to review. Thanks