### PR TITLE
ECPINT-860 fixed card payment intermittent issue

### DIFF
--- a/Cartridges/int_checkoutcom/cartridge/scripts/helpers/ckoHelper.js
+++ b/Cartridges/int_checkoutcom/cartridge/scripts/helpers/ckoHelper.js
@@ -282,10 +282,10 @@ var ckoHelper = {
     paymentSuccess: function (gatewayResponse) {
     	if (gatewayResponse.hasOwnProperty('response_code')) {
 
-    		return gatewayResponse.response_code == "10000" || gatewayResponse.response_code == '10100' || gatewayResponse.response_code == '10200';
+    		return gatewayResponse.response_code == 10000 || gatewayResponse.response_code == 10100 || gatewayResponse.response_code == 10200;
     	}else if(gatewayResponse.hasOwnProperty('actions')){
 
-    		return gatewayResponse.actions[0].response_code == "10000" || gatewayResponse.actions[0].response_code == '10100' || gatewayResponse.actions[0].response_code == '10200';
+    		return gatewayResponse.actions[0].response_code == 10000 || gatewayResponse.actions[0].response_code == 10100 || gatewayResponse.actions[0].response_code == 10200;
     	}else if(gatewayResponse.hasOwnProperty('source')){
 
     		return gatewayResponse.source.type == 'sofort' || 'bancontact';


### PR DESCRIPTION
There seems to be a strange issue which is only happening intermittently. When completing a payment and trying to be re-routed to the success page and error occurs, which takes you to an error page instead of the success page. However an order is still created and a transaction, so the order is still going through. Please can we have a look at this. Thank you.