### PR TITLE
ECPINT-1225 Fixed Gateway object properties being deleted

### DIFF
--- a/Cartridges/int_checkoutcom_sfra/cartridge/scripts/helpers/ckoHelper.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/scripts/helpers/ckoHelper.js
@@ -105,12 +105,14 @@ var ckoHelper = {
      * @param {Object} gatewayData The gateway data
      */
     log: function(dataType, gatewayData) {
+        // Create's a deep copy gatewayData, this will prevent data being deleted.
+        var cloneGatewayData = JSON.parse(JSON.stringify(gatewayData));
         if (this.getValue('ckoDebugEnabled') === true) {
             // Get the logger
             var logger = Logger.getLogger('ckodebug');
 
             // Remove sensitive data
-            var cleanData = this.removeSentisiveData(gatewayData);
+            var cleanData = this.removeSentisiveData(cloneGatewayData);
 
             // Log the data
             if (logger) {


### PR DESCRIPTION
 I have implemented a deep copy of the gateway Object, when parse to the log helper method and this copy can have property deleted with no effect on the original object.