### PR TITLE
ECPINT-1341-press-submit-order-twice-BUG

### DIFF
--- a/Cartridges/int_checkoutcom_sfra/cartridge/static/default/js/cardPayment.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/static/default/js/cardPayment.js
@@ -16,7 +16,7 @@ function initCheckoutcomCardValidation() {
 }
 
 function cardFormValidation() {
-    $('button.submit-payment').off('click touch').one('click touch', function(e) {
+    $('button.submit-payment').off('click touch').on('click touch', function(e) {
     // Reset the form error messages
         resetFormErrors();
 
@@ -43,10 +43,11 @@ function cardFormValidation() {
         });
 
         // Prevent submission
-        if (cardFields.length > 0) {
-            // Prevent the default button click behaviour
-            e.preventDefault();
-            e.stopImmediatePropagation();
+        for (var i = 0; i < cardFields.length; i++) {
+            if (cardFields[i].error == 1) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+            }
         }
     });
 }


### PR DESCRIPTION
- modified submission prevention by checking if the error attribute is true
- modified event from triggering once to triggering each time the button is clicked