### PR TITLE
ECPINT-1254-SG-apmOption-available-anytime-BUG

### DIFF
--- a/Cartridges/int_checkoutcom/cartridge/scripts/config/ckoApmFilterConfig.js
+++ b/Cartridges/int_checkoutcom/cartridge/scripts/config/ckoApmFilterConfig.js
@@ -1,95 +1,95 @@
 'use strict';
-var customPrefs = dw.system.Site.getCurrent().getPreferences().getCustom();
+
 var ckoApmFilterConfig = {
     ideal: {
         countries: ['NL'],
         currencies: ['EUR'],
-        enabled: customPrefs['ckoIdealEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoIdealEnabled')
     },
     boleto: {
         countries: ['BR'],
         currencies: ['BRL', 'USD'],
-        enabled: customPrefs['ckoBoletoEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoBoletoEnabled')
     },
     bancontact: {
         countries: ['BE'],
         currencies: ['EUR'],
-        enabled: customPrefs['ckoBancontactEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoBancontactEnabled')
     },
     benefit: {
         countries: ['BH'],
         currencies: ['BHD'],
-        enabled: customPrefs['ckoBenefitEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoBenefitEnabled')
     },
     giro: {
         countries: ['DE'],
         currencies: ['EUR'],
-        enabled: customPrefs['ckoGiroEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoGiroEnabled')
     },
     eps: {
         countries: ['AT'],
         currencies: ['EUR'],
-        enabled: customPrefs['ckoEpsEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoEpsEnabled')
     },
     sofort: {
         countries: ['AT', 'BE', 'DE', 'ES', 'IT', 'NL'],
         currencies: ['EUR'],
-        enabled: customPrefs['ckoSofortEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoSofortEnabled')
     },
     knet: {
         countries: ['KW'],
         currencies: ['KWD'],
-        enabled: customPrefs['ckoKnetEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoKnetEnabled')
     },
     qpay: {
         countries: ['QA'],
         currencies: ['QAR'],
-        enabled: customPrefs['ckoQpayEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoQpayEnabled')
     },
     fawry: {
         countries: ['EG'],
         currencies: ['EGP'],
-        enabled: customPrefs['ckoFawryEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoFawryEnabled')
     },
     multibanco: {
         countries: ['PT'],
         currencies: ['EUR'],
-        enabled: customPrefs['ckoMultibancoEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoMultibancoEnabled')
     },
     poli: {
         countries: ['AU', 'NZ'],
         currencies: ['AUD', 'NZD'],
-        enabled: customPrefs['ckoPoliEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoPoliEnabled')
     },
     sepa: {
         countries: ['AT', 'BE', 'CY', 'DE', 'EE', 'ES', 'FI', 'FR', 'GR', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PT', 'SI', 'SK', 'AD', 'BG', 'CH', 'CZ', 'DK', 'GB', 'HR', 'HU', 'IS', 'LI', 'MC', 'NO', 'PL', 'RO', 'SM', 'SE', 'VA'],
         currencies: ['EUR'],
-        enabled: customPrefs['ckoSepaEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoSepaEnabled')
     },
     p24: {
         countries: ['PL'],
         currencies: ['EUR', 'PLN'],
-        enabled: customPrefs['ckoP24Enabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoP24Enabled')
     },
     klarna: {
         countries: ['AT', 'DK', 'FI', 'DE', 'NL', 'NO', 'SE', 'UK', 'GB'],
         currencies: ['EUR', 'DKK', 'GBP', 'NOK', 'SEK'],
-        enabled: customPrefs['ckoKlarnaEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoKlarnaEnabled')
     },
     oxxo: {
         countries: ['MX'],
         currencies: ['MXN'],
-        enabled: customPrefs['ckoOxxoEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoOxxoEnabled')
     },
     alipay: {
         countries: ['CN'],
         currencies: ['USD', 'CNY'],
-        enabled: customPrefs['ckoAlipayEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoAlipayEnabled')
     },
     paypal: {
         countries: ['*'],
         currencies: ['AUD', 'BRL', 'CAD', 'CZK', 'DKK', 'EUR', 'HKD', 'HUF', 'INR', 'ILS', 'JPY', 'MYR', 'MXN', 'TWD', 'NZD', 'NOK', 'PHP', 'PLN', 'GBP', 'RUB', 'SGD', 'SEK', 'CHF', 'THB', 'USD'],
-        enabled: customPrefs['ckoPaypalEnabled']
+        enabled: dw.system.Site.getCurrent().getCustomPreferenceValue('ckoPaypalEnabled')
     },
 };
 

--- a/Cartridges/int_checkoutcom/cartridge/scripts/config/ckoApmFilterConfig.js
+++ b/Cartridges/int_checkoutcom/cartridge/scripts/config/ckoApmFilterConfig.js
@@ -1,77 +1,95 @@
 'use strict';
-
+var customPrefs = dw.system.Site.getCurrent().getPreferences().getCustom();
 var ckoApmFilterConfig = {
     ideal: {
         countries: ['NL'],
         currencies: ['EUR'],
+        enabled: customPrefs['ckoIdealEnabled']
     },
     boleto: {
         countries: ['BR'],
         currencies: ['BRL', 'USD'],
+        enabled: customPrefs['ckoBoletoEnabled']
     },
     bancontact: {
         countries: ['BE'],
         currencies: ['EUR'],
+        enabled: customPrefs['ckoBancontactEnabled']
     },
     benefit: {
         countries: ['BH'],
         currencies: ['BHD'],
+        enabled: customPrefs['ckoBenefitEnabled']
     },
     giro: {
         countries: ['DE'],
         currencies: ['EUR'],
+        enabled: customPrefs['ckoGiroEnabled']
     },
     eps: {
         countries: ['AT'],
         currencies: ['EUR'],
+        enabled: customPrefs['ckoEpsEnabled']
     },
     sofort: {
         countries: ['AT', 'BE', 'DE', 'ES', 'IT', 'NL'],
         currencies: ['EUR'],
+        enabled: customPrefs['ckoSofortEnabled']
     },
     knet: {
         countries: ['KW'],
         currencies: ['KWD'],
+        enabled: customPrefs['ckoKnetEnabled']
     },
     qpay: {
         countries: ['QA'],
         currencies: ['QAR'],
+        enabled: customPrefs['ckoQpayEnabled']
     },
     fawry: {
         countries: ['EG'],
         currencies: ['EGP'],
+        enabled: customPrefs['ckoFawryEnabled']
     },
     multibanco: {
         countries: ['PT'],
         currencies: ['EUR'],
+        enabled: customPrefs['ckoMultibancoEnabled']
     },
     poli: {
         countries: ['AU', 'NZ'],
         currencies: ['AUD', 'NZD'],
+        enabled: customPrefs['ckoPoliEnabled']
     },
     sepa: {
         countries: ['AT', 'BE', 'CY', 'DE', 'EE', 'ES', 'FI', 'FR', 'GR', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PT', 'SI', 'SK', 'AD', 'BG', 'CH', 'CZ', 'DK', 'GB', 'HR', 'HU', 'IS', 'LI', 'MC', 'NO', 'PL', 'RO', 'SM', 'SE', 'VA'],
         currencies: ['EUR'],
+        enabled: customPrefs['ckoSepaEnabled']
     },
     p24: {
         countries: ['PL'],
         currencies: ['EUR', 'PLN'],
+        enabled: customPrefs['ckoP24Enabled']
     },
     klarna: {
         countries: ['AT', 'DK', 'FI', 'DE', 'NL', 'NO', 'SE', 'UK', 'GB'],
         currencies: ['EUR', 'DKK', 'GBP', 'NOK', 'SEK'],
+        enabled: customPrefs['ckoKlarnaEnabled']
     },
     oxxo: {
         countries: ['MX'],
         currencies: ['MXN'],
+        enabled: customPrefs['ckoOxxoEnabled']
     },
     alipay: {
         countries: ['CN'],
         currencies: ['USD', 'CNY'],
+        enabled: customPrefs['ckoAlipayEnabled']
     },
     paypal: {
         countries: ['*'],
         currencies: ['AUD', 'BRL', 'CAD', 'CZK', 'DKK', 'EUR', 'HKD', 'HUF', 'INR', 'ILS', 'JPY', 'MYR', 'MXN', 'TWD', 'NZD', 'NOK', 'PHP', 'PLN', 'GBP', 'RUB', 'SGD', 'SEK', 'CHF', 'THB', 'USD'],
+        enabled: customPrefs['ckoPaypalEnabled']
     },
 };
 

--- a/Cartridges/int_checkoutcom/cartridge/static/default/js/apm.js
+++ b/Cartridges/int_checkoutcom/cartridge/static/default/js/apm.js
@@ -72,21 +72,28 @@ function alternativePaymentsFilter() {
 
             // Assign the apms filter Object from the response object to apmfilterObject variable
             var apmsFilterObject = responseObject.ckoApmFilterConfig;
+            var anyApmEnabled = false;
 
             // Loops through the apmfilterObject
             for (var apms in apmsFilterObject) {
-            	var condition1 = apmsFilterObject[apms].countries.includes(filterObject.country.toUpperCase());
-            	var condition2 = apmsFilterObject[apms].countries.includes('*');
-            	var condition3 = apmsFilterObject[apms].currencies.includes(filterObject.currency);
+                var condition1 = apmsFilterObject[apms].countries.includes(filterObject.country.toUpperCase());
+                var condition2 = apmsFilterObject[apms].countries.includes('*');
+                var condition3 = apmsFilterObject[apms].currencies.includes(filterObject.currency);
+                var condition4 = apmsFilterObject[apms].enabled;
 
             	/*
             	 * If the current apm country-code and currency-code in
             	 * the list of apms, match the current country-code and currency-code
             	 */
-                if ((condition1 || condition2) && condition3) {
+                if ((condition1 || condition2) && condition3 && condition4) {
+                    anyApmEnabled = true;
                 	// Show Apm in template
                 	$('#' + apms).show();
                 }
+            }
+            // Hide the option to select APMs if none are available
+            if(!anyApmEnabled) {
+                document.getElementById('is-CHECKOUTCOM_APM').parentElement.parentElement.style.display = 'none';
             }
         }
     };


### PR DESCRIPTION
- added new property in config file so we can check if the custom preference was enabled
- in client-side js, if no APM passes the filtering, we hide the APM option