### PR TITLE
ECPINT-1520-applePay-option-visible-billing-step

### DIFF
--- a/Cartridges/int_checkoutcom/cartridge/static/default/js/applepay.js
+++ b/Cartridges/int_checkoutcom/cartridge/static/default/js/applepay.js
@@ -63,6 +63,7 @@ async function launchApplePay() {
             }
         );
     } else {
+        document.getElementById('is-CHECKOUTCOM_APPLE_PAY').parentElement.parentElement.style.display = 'none';
         jQuery('#ckoApplePayButton').hide();
         jQuery('.ckoApplePayIncompatible').show();
     }


### PR DESCRIPTION
- added logic if !window.ApplePaySession, hide button for Apple Pay