### PR TITLE
ECPINT-1479-transactions-table-not-visible-BUG

### DIFF
--- a/Cartridges/bm_checkoutcom/cartridge/scripts/helpers/CKOHelper.js
+++ b/Cartridges/bm_checkoutcom/cartridge/scripts/helpers/CKOHelper.js
@@ -185,7 +185,7 @@ var CKOHelper = {
      */
     getProcessorId: function(instrument) {
         var paymentMethod = PaymentMgr.getPaymentMethod(instrument.getPaymentMethod());
-        if (paymentMethod) {
+        if (paymentMethod && paymentMethod.getPaymentProcessor()) {
             return paymentMethod.getPaymentProcessor().getID();
         }
         return '';


### PR DESCRIPTION
- added logic to avoid error being thrown when no payment processor is available for a payment method