### PR TITLE
ECPINT-1350-payment-with-saved-card-fails-BUG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ link-checkoutcom.code-workspace
 dw.json
 node_modules/
 .vscode/
+cartridges/app_storefront_base
+cartridges/*/cartridge/static

--- a/Cartridges/int_checkoutcom_sfra/cartridge/client/default/js/cardPayment.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/client/default/js/cardPayment.js
@@ -1,56 +1,89 @@
 'use strict';
 
-require('./checkoutcom.js');
+var checkoutcom = require('./checkoutcom.js');
+
+// Enable the saved card selection
+require('./savedCardPayment');
 
 function initCheckoutcomCardValidation() {
-    // Is card payment
-    var condition1 = $('input[name="dwfrm_billing_paymentMethod"]').val() === 'CHECKOUTCOM_CARD';
-
-    // Is card form
-    var condition2 = $('.saved-card-tab').hasClass('active');
-
-    // Run the default form validation
-    if (condition1 && !condition2) {
-        cardFormValidation();
-    } else if (condition1 && condition2) {
-        savedCardFormValidation();
-    }
-}
-
-function cardFormValidation() {
     $('button.submit-payment').off('click touch').on('click touch', function(e) {
-    // Reset the form error messages
-    checkoutcom.resetFormErrors();
+        // Reset the form error messages
+        checkoutcom.resetFormErrors();
+        // Is card payment
+        var condition1 = $('input[name="dwfrm_billing_paymentMethod"]').val() === 'CHECKOUTCOM_CARD';
 
-        // Prepare the errors array
-        var cardFields = [];
+        // Is card form
+        var condition2 = $('.saved-card-tab').hasClass('active');
 
-        // Card number validation
-        cardFields.push(checkCardNumber());
+        // Run the default form validation
+        if (condition1 && !condition2) {
 
-        // Card expiration month validation
-        cardFields.push(checkCardExpirationMonth());
+            // Empty saved card fields in case they were populated
+            // Set the selected card uuid
+            $('input[name="dwfrm_billing_savedCardForm_selectedCardUuid"]').val('');
+            $('input[name="dwfrm_billing_savedCardForm_selectedCardCvv"]').val('');
+            // Prepare the errors array
+            var cardFields = [];
 
-        // Card expiration year validation
-        cardFields.push(checkCardExpirationYear());
+            // Card number validation
+            cardFields.push(checkCardNumber());
 
-        // Security code validation
-        cardFields.push(checkCardCvv());
+            // Card expiration month validation
+            cardFields.push(checkCardExpirationMonth());
 
-        // Handle errors
-        $.each(cardFields, function(i, field) {
-            if (field && field.error === 1) {
-                $('#' + field.id).next('.invalid-feedback').show();
+            // Card expiration year validation
+            cardFields.push(checkCardExpirationYear());
+
+            // Security code validation
+            cardFields.push(checkCardCvv());
+
+            // Handle errors
+            $.each(cardFields, function(i, field) {
+                if (field && field.error === 1) {
+                    $('#' + field.id).next('.invalid-feedback').show();
+                }
+            });
+
+            // Prevent submission
+            for (var i = 0; i < cardFields.length; i++) {
+                if (cardFields[i].error == 1) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                }
             }
-        });
+            // Validate saved card form
+        } else if (condition1 && condition2) {
+            // Prepare some variables
+            var savedCard = $('.saved-payment-instrument');
+            var buttonEvent = e;
 
-        // Prevent submission
-        for (var i = 0; i < cardFields.length; i++) {
-            if (cardFields[i].error == 1) {
-                e.preventDefault();
-                e.stopImmediatePropagation();
-            }
+            // Implement the event
+            savedCard.each(function(i) {
+                // Prepare the variables
+                var self = $(this);
+                var cvvField = self.find('input.saved-payment-security-code');
+
+                // The saved card is selected
+                var condition1 = self.hasClass('selected-payment');
+
+                // Field is empty
+                var condition2 = cvvField.val() === '';
+
+                // Field is numeric
+                var condition3 = cvvField.val() % 1 === 0;
+
+                // Field validation
+                if (condition1 && (condition2 || !condition3)) {
+                    // Prevent the default button click behaviour
+                    buttonEvent.preventDefault();
+                    buttonEvent.stopImmediatePropagation();
+
+                    // Show the CVV error
+                    self.find('.invalid-feedback').show();
+                }
+            });
         }
+
     });
 }
 
@@ -137,51 +170,6 @@ function checkCardCvv() {
 function getFormattedNumber(num) {
     return num.replace(/\s/g, '');
 }
-
-/**
- * Validate the save card form
- */
-function savedCardFormValidation() {
-    // Enable the saved card selection
-    require('./savedCardPayment').savedCardSelection();
-
-    // Submit event
-    $('button.submit-payment').off('click touch').one('click touch', function(e) {
-    // Reset the form error messages
-        checkoutcom.resetFormErrors();
-
-        // Prepare some variables
-        var savedCard = $('.saved-payment-instrument');
-        var buttonEvent = e;
-
-        // Implement the event
-        savedCard.each(function(i) {
-            // Prepare the variables
-            var self = $(this);
-            var cvvField = self.find('input.saved-payment-security-code');
-
-            // The saved card is selected
-            var condition1 = self.hasClass('selected-payment');
-
-            // Field is empty
-            var condition2 = cvvField.val() === '';
-
-            // Field is numeric
-            var condition3 = cvvField.val() % 1 === 0;
-
-            // Field validation
-            if (condition1 && (condition2 || !condition3)) {
-                // Prevent the default button click behaviour
-                buttonEvent.preventDefault();
-                buttonEvent.stopImmediatePropagation();
-
-                // Show the CVV error
-                self.find('.invalid-feedback').show();
-            }
-        });
-    });
-}
-
 
 document.addEventListener('DOMContentLoaded', function() {
     initCheckoutcomCardValidation();

--- a/Cartridges/int_checkoutcom_sfra/cartridge/client/default/js/checkout/billing.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/client/default/js/checkout/billing.js
@@ -248,9 +248,13 @@ module.exports = {
     selectSavedPaymentInstrument: function () {
         $(document).on('click', '.saved-payment-instrument', function (e) {
             e.preventDefault();
-            $('.saved-payment-security-code').val('');
-            $('.saved-payment-instrument').removeClass('selected-payment');
-            $(this).addClass('selected-payment');
+
+            if(!$(this).hasClass("selected-payment")) {
+                $('.saved-payment-security-code').val('');
+                $('.saved-payment-instrument').removeClass('selected-payment');
+                $(this).addClass('selected-payment');
+            }
+            
             $('.saved-payment-instrument .card-image').removeClass('checkout-hidden');
             $('.saved-payment-instrument .security-code-input').addClass('checkout-hidden');
             $('.saved-payment-instrument.selected-payment' +

--- a/Cartridges/int_checkoutcom_sfra/cartridge/client/default/js/checkoutcom.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/client/default/js/checkoutcom.js
@@ -73,12 +73,13 @@ function initFormValidation() {
         window[func]();
     }
 }
-
-function resetFormErrors() {
-    $('.invalid-feedback').hide();
-    $('.credit-card-content .is-invalid').each(function() {
-        $(this).removeClass('is-invalid');
-    });
+module.exports = {
+    resetFormErrors: function() {
+        $('.invalid-feedback').hide();
+        $('.credit-card-content .is-invalid').each(function() {
+            $(this).removeClass('is-invalid');
+        });
+    }
 }
 
 function loadTranslations() {

--- a/Cartridges/int_checkoutcom_sfra/cartridge/client/default/js/savedCardPayment.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/client/default/js/savedCardPayment.js
@@ -1,28 +1,19 @@
 'use strict';
-
-/**
- * Handle the saved card selection
- */
-function savedCardSelection() {
-    // Target saved card
-    var savedCardItem = $('.saved-payment-instrument');
+    /**
+    * Handle the saved card selection
+    */
+        // Set the selected card uuid
+$('.saved-payment-instrument').off('click touch').on('click touch', function(e) {
+    var self = $(this);
 
     // Set the selected card uuid
-    savedCardItem.off('click touch').one('click touch', function(e) {
-        var self = $(this);
+    $('input[name="dwfrm_billing_savedCardForm_selectedCardUuid"]').val(
+        self.data('uuid')
+    );
 
-        // Set the selected card uuid
-        $('input[name="dwfrm_billing_savedCardForm_selectedCardUuid"]').val(
-            self.data('uuid')
-        );
-
-        // Set the selected card security code event
-        var cvvField = self.find('input.saved-payment-security-code');
-        cvvField.off('change').one('change', function(e) {
-            $('input[name="dwfrm_billing_savedCardForm_selectedCardCvv"]').val($(this).val());
-        });
+    // Set the selected card security code event
+    var cvvField = self.find('input.saved-payment-security-code');
+    cvvField.off('change').on('change', function(e) {
+        $('input[name="dwfrm_billing_savedCardForm_selectedCardCvv"]').val($(this).val());
     });
-
-    // Select the first item in the list
-    savedCardItem.first().addClass('selected-payment');
-}
+});

--- a/Cartridges/int_checkoutcom_sfra/cartridge/controllers/PaymentInstruments.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/controllers/PaymentInstruments.js
@@ -5,6 +5,7 @@ var server = require('server');
 var csrfProtection = require('*/cartridge/scripts/middleware/csrf');
 var userLoggedIn = require('*/cartridge/scripts/middleware/userLoggedIn');
 var consentTracking = require('*/cartridge/scripts/middleware/consentTracking');
+var savedCardHelper = require('*/cartridge/scripts/helpers/savedCardHelper');
 
 /**
  * Checks if a credit card is valid or not
@@ -153,6 +154,7 @@ server.get(
         for (var j = 0, k = months.length; j < k; j++) {
             months[j].selected = false;
         }
+
         res.render('account/payment/addPayment', {
             paymentForm: paymentForm,
             expirationYears: creditCardExpirationYears,
@@ -210,7 +212,9 @@ server.post('SavePayment', csrfProtection.validateAjaxRequest, function (req, re
                 var processor = PaymentMgr.getPaymentMethod('CHECKOUTCOM_CARD').getPaymentProcessor();
                 var token = HookMgr.callHook(
                     'app.payment.processor.' + processor.ID.toLowerCase(),
-                    'createToken'
+                    'createToken',
+                    result,
+                    req
                 );
 
                 paymentInstrument.setCreditCardToken(token);

--- a/Cartridges/int_checkoutcom_sfra/cartridge/scripts/helpers/savedCardHelper.js
+++ b/Cartridges/int_checkoutcom_sfra/cartridge/scripts/helpers/savedCardHelper.js
@@ -103,7 +103,7 @@ var savedCardHelper = {
         // Get the customer profile
         var customerNo = req.currentCustomer.profile.customerNo;
         var customerProfile = CustomerMgr.getCustomerByCustomerNumber(customerNo).getProfile();
-        var processorId = paymentData.paymentMethod.value;
+        var processorId = paymentData.paymentMethod.htmlValue;
 
         // Build the customer full name
         var fullName = ckoHelper.getCustomerFullName(customerProfile);


### PR DESCRIPTION
- modified cardPayment.js to work better with webpack
- modified billing.js so if a different saved card is used, the old info is deleted
- modified checkoutcom.js to work better with webpack
- modified savedCardPayment to work better with webpack, removed autoselect of first saved card
- modified webhook call in PaymentInstruments.js
- corrected savedCardHelper to get the value of the processorId
- added createToken function in CHECKOUTCOM_CARD.js which will create a token for the saved credit card
then with that token will request an id
- updated gitignore