### PR TITLE
modified deprecated API usage

### DIFF
--- a/20.2.0/Cartridges/int_checkoutcom_sfra/cartridge/scripts/hooks/payment/processor/CHECKOUTCOM_CARD.js
+++ b/20.2.0/Cartridges/int_checkoutcom_sfra/cartridge/scripts/hooks/payment/processor/CHECKOUTCOM_CARD.js
@@ -41,7 +41,7 @@ function createToken(paymentData) {
                 type: 'token',
                 token: tokenResponse.token,
             },
-            currency: Site.getCurrent().getCurrencyCode(),
+            currency: Site.getCurrent().getDefaultCurrency(),
             risk: { enabled: false },
             billing_descriptor: ckoHelper.getBillingDescriptor(),
         };

--- a/20.3.0/Cartridges/int_checkoutcom_sfra/cartridge/scripts/hooks/payment/processor/CHECKOUTCOM_CARD.js
+++ b/20.3.0/Cartridges/int_checkoutcom_sfra/cartridge/scripts/hooks/payment/processor/CHECKOUTCOM_CARD.js
@@ -40,7 +40,7 @@ function createToken(paymentData) {
                 type: "token",
                 token: tokenResponse.token
             },
-            currency: Site.getCurrent().getCurrencyCode(),
+            currency: Site.getCurrent().getDefaultCurrency(),
             risk: { enabled: false },
             billing_descriptor: ckoHelper.getBillingDescriptor()
         }


### PR DESCRIPTION
- getCurrencyCode for Site Class is deprecated, it is recomended to use getDefaultCurrency()