### PR TITLE
ECPINT-2784-masked-card-number

### DIFF
--- a/Cartridges/int_checkoutcom/cartridge/controllers/CKOMain.js
+++ b/Cartridges/int_checkoutcom/cartridge/controllers/CKOMain.js
@@ -174,6 +174,7 @@ function getCardsList() {
                 data.push({
                     cardId: applicablePaymentCards[i].getUUID(),
                     cardNumber: applicablePaymentCards[i].getCreditCardNumber(),
+                    cardToken: applicablePaymentCards[i].getCreditCardToken(),
                     cardHolder: applicablePaymentCards[i].creditCardHolder,
                     cardType: applicablePaymentCards[i].getCreditCardType(),
                     expiryMonth: applicablePaymentCards[i].creditCardExpirationMonth,

--- a/Cartridges/int_checkoutcom/cartridge/forms/default/cardPaymentForm.xml
+++ b/Cartridges/int_checkoutcom/cartridge/forms/default/cardPaymentForm.xml
@@ -57,6 +57,8 @@
 	<!-- Optional flags -->
 	<field formid="saveCard" label="creditcard.savecard" type="boolean" mandatory="false" default-value="false" />
 
+	<field formid="cardToken" type="string" mandatory="false" default-value="false" />
+
 	<!-- Confirm action -->
     <action formid="confirm" valid-form="true"/>
 </form>

--- a/Cartridges/int_checkoutcom/cartridge/scripts/helpers/ckoHelper.js
+++ b/Cartridges/int_checkoutcom/cartridge/scripts/helpers/ckoHelper.js
@@ -777,10 +777,11 @@ var ckoHelper = {
 
         // Get the payment processor
         var paymentInstrument = args.PaymentInstrument;
-        var paymentProcessor = PaymentMgr.getPaymentMethod(paymentInstrument.getPaymentMethod()).getPaymentProcessor();
+        var paymentMethodName = PaymentMgr.getPaymentMethod(paymentInstrument.getPaymentMethod()).getPaymentProcessor().getID();
+        var paymentMethodId = paymentMethodName == 'CHECKOUTCOM_CARD' ? 'CREDIT_CARD' : paymentMethodName;
 
         // Add the payment processor to the metadata
-        meta.payment_processor = paymentProcessor.getID();
+        meta.payment_processor = paymentMethodId;
 
         return meta;
     },

--- a/Cartridges/int_checkoutcom/cartridge/static/default/js/checkoutcom.js
+++ b/Cartridges/int_checkoutcom/cartridge/static/default/js/checkoutcom.js
@@ -66,6 +66,7 @@ function getCardData(elt, dataUrl) {
                             cardType: cards[i].cardType,
                             cardHolder: cards[i].cardHolder,
                             cardType: cards[i].cardType,
+                            cardToken: cards[i].cardToken,
                             expiryMonth: cards[i].expiryMonth,
                             expiryYear: cards[i].expiryYear,
                         });
@@ -86,12 +87,14 @@ function getCardData(elt, dataUrl) {
 function setFields(data)
 {
     var $creditCard = $('[data-method="CREDIT_CARD"]');
-    $creditCard.find('input[name$="_cardPaymentForm_owner"]').val(data.cardHolder).trigger('change');
-    $creditCard.find('input[name$="_cardPaymentForm_number"]').val(data.cardNumber).trigger('change');
+    $creditCard.find('input[name$="_cardPaymentForm_owner"]').val(data.cardHolder);
+    $creditCard.find('input[name$="_cardPaymentForm_number"]').val(data.cardNumber);
+    $creditCard.find('input[name$="_cardPaymentForm_cardToken"]').val(data.cardToken);
     
     // enable card data formating
     setSchema('#dwfrm_cardPaymentForm_number');
-    $creditCard.find('[name$="_month"]').val(data.expiryMonth).trigger('change');
-    $creditCard.find('[name$="_year"]').val(data.expiryYear).trigger('change');
-    $creditCard.find('input[name$="_cvn"]').val('').trigger('change');
+    $creditCard.find('input[name$="_cardPaymentForm_number"]').val(data.cardNumber);
+    $creditCard.find('[name$="_month"]').val(data.expiryMonth);
+    $creditCard.find('[name$="_year"]').val(data.expiryYear);
+    $creditCard.find('input[name$="_cvn"]').val('');
 }

--- a/Cartridges/int_checkoutcom/cartridge/templates/default/cardPayments/cardPaymentForm.isml
+++ b/Cartridges/int_checkoutcom/cartridge/templates/default/cardPayments/cardPaymentForm.isml
@@ -75,6 +75,8 @@
 
 	<!-- MADA BIN filter URL -->
   	<input type="hidden" id="ckoMadaBinUrl" value="${URLUtils.https('CKOMain-GetMadaBin')}" />
+
+  	<isinputfield type="hidden" id="cardToken" formfield="${pdict.CurrentForms.cardPaymentForm.cardToken}"/>
 	
 </div>
 


### PR DESCRIPTION
**Notes**
This PR aims to fix the display of card numbers to '****' by saving the card token on the SFCC card object

- changed logic to add the card Token in front end for saved cards functionality
- added customer_id and card_uuid in api call
- added logic to send token instead of card no if available